### PR TITLE
Add icon generation for Ammo

### DIFF
--- a/FModel/App.config
+++ b/FModel/App.config
@@ -112,6 +112,9 @@
             <setting name="UpdateSettings" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="createIconForAmmo" serializeAs="String">
+                <value>True</value>
+            </setting>
         </FModel.Properties.Settings>
     </userSettings>
 </configuration>

--- a/FModel/Forms/IconGeneratorAssets.Designer.cs
+++ b/FModel/Forms/IconGeneratorAssets.Designer.cs
@@ -54,7 +54,8 @@
             "Consumables & Weapons",
             "Cosmetics",
             "Traps",
-            "Variants"});
+            "Variants",
+            "Ammo"});
             this.checkedAssets.Location = new System.Drawing.Point(12, 12);
             this.checkedAssets.Name = "checkedAssets";
             this.checkedAssets.Size = new System.Drawing.Size(307, 274);

--- a/FModel/Forms/IconGeneratorAssets.cs
+++ b/FModel/Forms/IconGeneratorAssets.cs
@@ -20,6 +20,7 @@ namespace FModel.Forms
             checkedAssets.SetItemChecked(2, Properties.Settings.Default.createIconForCosmetics);
             checkedAssets.SetItemChecked(3, Properties.Settings.Default.createIconForTraps);
             checkedAssets.SetItemChecked(4, Properties.Settings.Default.createIconForVariants);
+            checkedAssets.SetItemChecked(5, Properties.Settings.Default.createIconForAmmo);
         }
 
         private void OKButton_Click(object sender, EventArgs e)
@@ -30,6 +31,7 @@ namespace FModel.Forms
             Properties.Settings.Default.createIconForCosmetics = checkedAssets.GetItemChecked(2);
             Properties.Settings.Default.createIconForTraps = checkedAssets.GetItemChecked(3);
             Properties.Settings.Default.createIconForVariants = checkedAssets.GetItemChecked(4);
+            Properties.Settings.Default.createIconForAmmo = checkedAssets.GetItemChecked(5);
 
             Properties.Settings.Default.Save(); //SAVE
             Close();

--- a/FModel/MainWindow.cs
+++ b/FModel/MainWindow.cs
@@ -1461,6 +1461,8 @@ namespace FModel
                         CreateItemIcon(itemId[i]);
                     else if (Settings.Default.createIconForVariants && (itemId[i].ExportType == "FortVariantTokenType"))
                         CreateItemIcon(itemId[i], false, false, true);
+                    else if (Settings.Default.createIconForAmmo && (itemId[i].ExportType == "FortAmmoItemDefinition"))
+                        CreateItemIcon(itemId[i], false, false, false, "ammo");
                     else if (itemId[i].ExportType == "FortChallengeBundleItemDefinition")
                         CreateChallengesIcon(itemId[i], parsedJson, questJson);
                     else if (itemId[i].ExportType == "Texture2D")
@@ -1476,7 +1478,7 @@ namespace FModel
                 Console.WriteLine(ex.Message);
             }
         }
-        private void CreateItemIcon(ItemsIdParser theItem, bool athIteDef = false, bool consAndWeap = false, bool variant = false)
+        private void CreateItemIcon(ItemsIdParser theItem, bool athIteDef = false, bool consAndWeap = false, bool variant = false, string SpecialMode = null)
         {
             UpdateConsole(CurrentUsedItem + " is a Cosmetic ID", Color.FromArgb(255, 66, 244, 66), "Success");
 
@@ -1487,7 +1489,11 @@ namespace FModel
             if (theItem.Series != null)
                 GetSeriesRarity(theItem, g);
             else
-                GetItemRarity(theItem, g);
+                // Special ammo force-rarity check
+                if (SpecialMode == "ammo")
+                    GetItemRarity(theItem, g, "ammo");
+                else
+                    GetItemRarity(theItem, g);
 
             ItemIconPath = string.Empty;
             if (Settings.Default.loadFeaturedImage == false)
@@ -1715,7 +1721,7 @@ namespace FModel
                 toDrawOn.DrawImage(rarityBg, new Point(0, 0));
             }
         }
-        private void GetItemRarity(ItemsIdParser theItem, Graphics toDrawOn)
+        private void GetItemRarity(ItemsIdParser theItem, Graphics toDrawOn, string SpecialMode = null)
         {
             if (theItem.Rarity == "EFortRarity::Transcendent")
             {
@@ -1750,6 +1756,13 @@ namespace FModel
             if (theItem.Rarity == null)
             {
                 Image rarityBg = Resources.U512;
+                toDrawOn.DrawImage(rarityBg, new Point(0, 0));
+            }
+
+            // Force common rarity if ammo, as ammo is always common in FN
+            if (SpecialMode == "ammo")
+            {
+                Image rarityBg = Resources.C512;
                 toDrawOn.DrawImage(rarityBg, new Point(0, 0));
             }
         }

--- a/FModel/Properties/Settings.Designer.cs
+++ b/FModel/Properties/Settings.Designer.cs
@@ -430,5 +430,17 @@ namespace FModel.Properties {
                 this["UpdateSettings"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool createIconForAmmo {
+            get {
+                return ((bool)(this["createIconForAmmo"]));
+            }
+            set {
+                this["createIconForAmmo"] = value;
+            }
+        }
     }
 }

--- a/FModel/Properties/Settings.settings
+++ b/FModel/Properties/Settings.settings
@@ -104,5 +104,8 @@
     <Setting Name="UpdateSettings" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="createIconForAmmo" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
- Added "SpecialMode" parameters for CreateItemIcon and GetItemRarity to force different behavior for different asset types, such as ammo, as ammo is always Common
- Added icon generation support for ammo