### PR TITLE
Challenge Design Fix

### DIFF
--- a/FModel/Methods/ChallengeGenerator/BundleDesign.cs
+++ b/FModel/Methods/ChallengeGenerator/BundleDesign.cs
@@ -26,7 +26,7 @@ namespace FModel
             if (Settings.Default.createIconForChallenges && myBundle.DisplayStyle != null)
             {
                 //main header
-                toDrawOn.FillRectangle(new SolidBrush(BundleInfos.getSecondaryColor(myBundle)), new Rectangle(0, 0, myBitmap.Width, 271));
+                toDrawOn.FillRectangle(new SolidBrush(BundleInfos.getSecondaryColor(myBundle)), new Rectangle(0, 0, myBitmap.Width, 281));
 
                 //gradient at left and right main header
                 LinearGradientBrush linGrBrush_left = new LinearGradientBrush(new Point(0, 282 / 2), new Point(282, 282 / 2),
@@ -146,7 +146,7 @@ namespace FModel
 
         private static void drawForbyteReward()
         {
-            string textureFile = "T_UI_PuzzleIcon_64";
+            string textureFile = "T_UI_ChallengeTile_Fortbytes";
             ItemIcon.ItemIconPath = JohnWick.AssetToTexture2D(textureFile);
 
             if (File.Exists(ItemIcon.ItemIconPath))


### PR DESCRIPTION
With the bitmap width of the Main Header being 271 you could see a small sliver of white on some challenges, by changing this to 281 the sliver won't show up anymore!

I've also changed the texturefile for the Fortbyte awards from the puzzle piece icon into the image seen on the challenge tile as it makes it simply look clearer as to what the reward is!