### PR TITLE
Fixed challenge counter of '...a single match'

### DIFF
--- a/FModel/Methods/ChallengeGenerator/BundleInfos.cs
+++ b/FModel/Methods/ChallengeGenerator/BundleInfos.cs
@@ -1,4 +1,4 @@
-﻿using csharp_wick;
+using csharp_wick;
 using FModel.Parser.Challenges;
 using FModel.Parser.Items;
 using FModel.Parser.Quests;
@@ -95,6 +95,9 @@ namespace FModel
                                     {
                                         string newQuest = questParser[x].Objectives[p].Description;
                                         long newCount = questParser[x].Objectives[p].Count;
+
+                                        if (questParser[x].BAthenaMustCompleteInSingleMatch != false && questParser[x].ObjectiveCompletionCount > 0)
+                                            newCount = questParser[x].ObjectiveCompletionCount;
 
                                         if (newQuest != oldQuest && newCount != oldCount)
                                         {

--- a/FModel/Parser/Quests/QuestParser.cs
+++ b/FModel/Parser/Quests/QuestParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -12,11 +12,14 @@ namespace FModel.Parser.Quests
         [JsonProperty("QuestType")]
         public string QuestType { get; set; }
 
+        [JsonProperty("bAthenaMustCompleteInSingleMatch")]
+        public bool BAthenaMustCompleteInSingleMatch { get; set; }
+
         [JsonProperty("bIncludedInCategories")]
         public bool BIncludedInCategories { get; set; }
 
         [JsonProperty("ObjectiveCompletionCount")]
-        public string ObjectiveCompletionCount { get; set; }
+        public long ObjectiveCompletionCount { get; set; }
 
         [JsonProperty("Rewards")]
         public Reward[] Rewards { get; set; }


### PR DESCRIPTION
Currently the challenges of 'a single match' always has a counter of 1, this fix it.