### PR TITLE
Simplify drawRewards in Challenges & fix the rewards of challenges.

### DIFF
--- a/FModel/MainWindow.cs
+++ b/FModel/MainWindow.cs
@@ -1333,7 +1333,7 @@ namespace FModel
                     BundleDesign.theY += 140;
 
                     //draw quest description
-                    BundleDesign.toDrawOn.DrawString(BundleInfos.BundleData[i].questDescr, new Font(FontUtilities.pfc.Families[1], isFortbyte ? 40 : 50), new SolidBrush(Color.White), new Point(100, BundleDesign.theY));
+                    BundleDesign.toDrawOn.DrawString(BundleInfos.BundleData[i].questDescr, new Font(FontUtilities.pfc.Families[1], isFortbyte ? (BundleInfos.BundleData[i].questDescr.Length > 80 ? 33 : 40) : 50), new SolidBrush(Color.White), new Point(100, BundleDesign.theY));
 
                     //draw slider + quest count
                     Image slider = Resources.Challenges_Slider;

--- a/FModel/Methods/ChallengeGenerator/BundleInfos.cs
+++ b/FModel/Methods/ChallengeGenerator/BundleInfos.cs
@@ -116,9 +116,14 @@ namespace FModel
                                             newCount = questParser[x].ObjectiveCompletionCount;
                                         }
 
+                                        bool isFortbyte = false;
+                                        var assetTypeToken = questParser[x].Rewards.Where(item => item.ItemPrimaryAssetId.PrimaryAssetType.Name == "Token").FirstOrDefault();
+                                        if (assetTypeToken != null)
+                                            isFortbyte = assetTypeToken.ItemPrimaryAssetId.PrimaryAssetName == "AthenaFortbyte";
+
                                         if (newQuest != oldQuest && newCount != oldCount)
                                         {
-                                            if (questParser[x].Rewards != null && !questFilePath.Contains("Fortbyte_"))
+                                            if (questParser[x].Rewards != null && !isFortbyte)
                                             {
                                                 try
                                                 {
@@ -150,8 +155,8 @@ namespace FModel
                                                     }
                                                 }
                                             }
-                                            else if (questFilePath.Contains("Fortbyte_"))
-                                                BundleData.Add(new BundleInfoEntry(newQuest, newCount, "AthenaFortbyte", questParser[x].Weight > 0 ? questParser[x].Weight.ToString() : "01"));
+                                            else if (isFortbyte && assetTypeToken != null)
+                                                BundleData.Add(new BundleInfoEntry(newQuest, newCount, assetTypeToken.ItemPrimaryAssetId.PrimaryAssetName, questParser[x].Weight > 0 ? questParser[x].Weight.ToString() : "01"));
                                             else
                                                 BundleData.Add(new BundleInfoEntry(newQuest, newCount, "", ""));
 

--- a/FModel/Methods/ChallengeGenerator/DrawingRewards.cs
+++ b/FModel/Methods/ChallengeGenerator/DrawingRewards.cs
@@ -26,14 +26,21 @@ namespace FModel
                 if (itemToExtract.Contains(":"))
                 {
                     var parts = itemToExtract.Split(':');
-                    if (parts[0] == "HomebaseBannerIcon") { DrawRewardBanner(parts[1]); }
-                    else { DrawRewardIcon(parts[1]); }
+                    if (parts[0] == "HomebaseBannerIcon")
+                        DrawRewardBanner(parts[1]);
+                    else
+                        DrawRewardIcon(parts[1]);
                 }
-                else if (string.Equals(itemToExtract, "athenabattlestar", StringComparison.CurrentCultureIgnoreCase)) { drawBattleStar(itemQuantity); }
-                else if (string.Equals(itemToExtract, "AthenaSeasonalXP", StringComparison.CurrentCultureIgnoreCase)) { drawSeasonalXp(itemQuantity); }
-                else if (string.Equals(itemToExtract, "MtxGiveaway", StringComparison.CurrentCultureIgnoreCase)) { drawMtxGiveaway(itemQuantity); }
-                else if (string.Equals(itemToExtract, "AthenaFortbyte", StringComparison.CurrentCultureIgnoreCase)) { drawFortbyte(itemQuantity); }
-                else { DrawRewardIcon(itemToExtract); }
+                else if (IsRewardType(itemToExtract, "athenabattlestar"))
+                    drawRewards("athenabattlestar", itemQuantity);
+                else if (IsRewardType(itemToExtract, "AthenaSeasonalXP"))
+                    drawRewards("AthenaSeasonalXP", itemQuantity);
+                else if (IsRewardType(itemToExtract, "MtxGiveaway"))
+                    drawRewards("MtxGiveaway", itemQuantity);
+                else if (IsRewardType(itemToExtract, "AthenaFortbyte"))
+                    drawRewards("AthenaFortbyte", itemQuantity);
+                else
+                    DrawRewardIcon(itemToExtract);
             }
         }
 
@@ -150,36 +157,59 @@ namespace FModel
             }
         }
 
-        private static void drawBattleStar(string quantity)
+        private static void drawRewards(string type, string quantity)
         {
-            Image rewardIcon = Resources.T_FNBR_BattlePoints_L;
-            BundleDesign.toDrawOn.DrawImage(ImageUtilities.ResizeImage(rewardIcon, 75, 75), new Point(2325, BundleDesign.theY + 22));
+            Image rewardIcon            = null;
+            GraphicsPath graphicsPath   = null;
 
-            GraphicsPath p = new GraphicsPath();
-            drawPathAndFill(p, quantity, Color.FromArgb(255, 143, 74, 32), Color.FromArgb(255, 255, 219, 103));
+            switch (type)
+            {
+                case "athenabattlestar":
+                {
+                    rewardIcon = Resources.T_FNBR_BattlePoints_L;
+                    BundleDesign.toDrawOn.DrawImage(ImageUtilities.ResizeImage(rewardIcon, 75, 75), new Point(2325, BundleDesign.theY + 22));
+
+                    graphicsPath = new GraphicsPath();
+                    drawPathAndFill(graphicsPath, quantity, Color.FromArgb(255, 143, 74, 32), Color.FromArgb(255, 255, 219, 103));
+                    break;
+                }
+                case "AthenaSeasonalXP":
+                {
+                    rewardIcon = Resources.T_FNBR_SeasonalXP_L;
+                    BundleDesign.toDrawOn.DrawImage(ImageUtilities.ResizeImage(rewardIcon, 75, 75), new Point(2325, BundleDesign.theY + 22));
+
+                    graphicsPath = new GraphicsPath();
+                    drawPathAndFill(graphicsPath, quantity, Color.FromArgb(255, 81, 131, 15), Color.FromArgb(255, 230, 253, 177));
+                    break;
+                }
+                case "MtxGiveaway":
+                {
+                    rewardIcon = Resources.T_Items_MTX_L;
+                    BundleDesign.toDrawOn.DrawImage(ImageUtilities.ResizeImage(rewardIcon, 75, 75), new Point(2325, BundleDesign.theY + 22));
+
+                    graphicsPath = new GraphicsPath();
+                    drawPathAndFill(graphicsPath, quantity, Color.FromArgb(255, 100, 160, 175), Color.FromArgb(255, 220, 230, 255));
+                    break;
+                }
+                case "AthenaFortbyte":
+                {
+                    BundleDesign.toDrawOn.DrawString("#" + Int32.Parse(quantity).ToString("D2"), new Font(FontUtilities.pfc.Families[1], 50), new SolidBrush(Color.White), new Point(2325, BundleDesign.theY + 22));
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            if (rewardIcon != null)
+                rewardIcon = null;
+
+            if (graphicsPath != null)
+                graphicsPath.Dispose();
         }
 
-        private static void drawSeasonalXp(string quantity)
+        private static bool IsRewardType(string value, string comparison)
         {
-            Image rewardIcon = Resources.T_FNBR_SeasonalXP_L;
-            BundleDesign.toDrawOn.DrawImage(ImageUtilities.ResizeImage(rewardIcon, 75, 75), new Point(2325, BundleDesign.theY + 22));
-
-            GraphicsPath p = new GraphicsPath();
-            drawPathAndFill(p, quantity, Color.FromArgb(255, 81, 131, 15), Color.FromArgb(255, 230, 253, 177));
-        }
-
-        private static void drawMtxGiveaway(string quantity)
-        {
-            Image rewardIcon = Resources.T_Items_MTX_L;
-            BundleDesign.toDrawOn.DrawImage(ImageUtilities.ResizeImage(rewardIcon, 75, 75), new Point(2325, BundleDesign.theY + 22));
-
-            GraphicsPath p = new GraphicsPath();
-            drawPathAndFill(p, quantity, Color.FromArgb(255, 100, 160, 175), Color.FromArgb(255, 220, 230, 255));
-        }
-
-        private static void drawFortbyte(string quantity)
-        {
-            BundleDesign.toDrawOn.DrawString("#" + Int32.Parse(quantity).ToString("D2"), new Font(FontUtilities.pfc.Families[1], 50), new SolidBrush(Color.White), new Point(2325, BundleDesign.theY + 22));
+            return string.Equals(value, comparison, StringComparison.CurrentCultureIgnoreCase);
         }
 
         /// <summary>


### PR DESCRIPTION
- 'QuestBundle_S9_Architect' did not correctly show the rewards for the implementation of Fortbytes challenges.