### PR TITLE
Add UWP Game support

### DIFF
--- a/FModel/Enums.cs
+++ b/FModel/Enums.cs
@@ -9,7 +9,8 @@
         Borderlands3,
         MinecraftDungeons,
         BattleBreakers,
-        Spellbreak
+        Spellbreak,
+        StateOfDecay2 // WIP
     }
 
     public enum EFModel
@@ -41,6 +42,7 @@
     {
         English,
         French,
+        AustralianEnglish,
         German,
         Italian,
         Spanish,

--- a/FModel/Globals.cs
+++ b/FModel/Globals.cs
@@ -57,6 +57,7 @@ namespace FModel
                 EGame.MinecraftDungeons => "Minecraft Dungeons",
                 EGame.BattleBreakers => "Battle Breakers",
                 EGame.Spellbreak => "Spellbreak",
+                EGame.StateOfDecay2 => "State of Decay 2",
                 EGame.Unknown => "Unknown",
                 _ => "Unknown",
             };

--- a/FModel/PakReader/Parsers/Objects/FSkeletalMeshAreaWeightedTriangleSampler.cs
+++ b/FModel/PakReader/Parsers/Objects/FSkeletalMeshAreaWeightedTriangleSampler.cs
@@ -13,7 +13,8 @@ namespace PakReader.Parsers.Objects
 
         internal FSkeletalMeshAreaWeightedTriangleSampler(PackageReader reader)
         {
-            throw new NotImplementedException(string.Format(FModel.Properties.Resources.ParsingNotSupported, "FSkeletalMeshAreaWeightedTriangleSampler"));
+            throw new NotImplementedException(string.Format(FModel.Properties.Resources.ParsingNotSupported,
+                "FSkeletalMeshAreaWeightedTriangleSampler"));
         }
     }
 }

--- a/FModel/Utils/Folders.cs
+++ b/FModel/Utils/Folders.cs
@@ -31,6 +31,7 @@ namespace FModel.Utils
                     "Dungeons" => EGame.MinecraftDungeons,
                     "WorldExplorers" => EGame.BattleBreakers,
                     "g3" => EGame.Spellbreak,
+                    "StateOfDecay2" => EGame.StateOfDecay2,
                     _ => EGame.Unknown,
                 };
             }
@@ -48,6 +49,7 @@ namespace FModel.Utils
                 EGame.MinecraftDungeons => "Dungeons",
                 EGame.BattleBreakers => "WorldExplorers",
                 EGame.Spellbreak => "g3",
+                EGame.StateOfDecay2 => "StateOfDecay2",
                 _ => string.Empty,
             };
 

--- a/FModel/Utils/Localizations.cs
+++ b/FModel/Utils/Localizations.cs
@@ -231,6 +231,19 @@ namespace FModel.Utils
                     ELanguage.Chinese => "zh-Hans",
                     _ => "en"
                 };
+            else if (Globals.Game.ActualGame == EGame.StateOfDecay2)
+                return lang switch
+                {
+                    ELanguage.English => "en-US",
+                    ELanguage.AustralianEnglish => "en-AU",
+                    ELanguage.Russian => "ru-RU",
+                    ELanguage.PortugueseBrazil => "pt-BR",
+                    ELanguage.Italian => "it-IT",
+                    ELanguage.French => "fr-FR",
+                    ELanguage.SpanishLatin => "es-MX",
+                    ELanguage.German => "de-DE",
+                    _ => "en"
+                };
             else
                 return "en";
         }

--- a/FModel/Utils/Paks.cs
+++ b/FModel/Utils/Paks.cs
@@ -43,6 +43,33 @@ namespace FModel.Utils
             return (string.Empty, string.Empty, string.Empty);
         }
 
+        // This method is in testing and is not recommended to be used other than for development purposes
+        public static (string, string) GetUWPPakFilesPath(string game)
+        {
+            var dir = "C:\\Program Files\\WindowsApps\\";
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    DebugHelper.WriteLine("{0} {1} {2}", "[FModel]", "[WindowsApps]", "Folder as been found");
+                    foreach (var directory in Directory.GetDirectories(dir))
+                        if (directory.Equals(game))
+                            return (game, directory);
+
+                    DebugHelper.WriteLine("{0} {1} {2}", "[FModel]", "[WindowsApps]", $"{game} not found");
+                    return (string.Empty, string.Empty);
+                }
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                DebugHelper.WriteLine("{0} {1} {2}", "[FModel]", "[WindowsApps]",
+                    $"{dir} can't be accessed without permission changes to the folder.");
+            }
+
+            DebugHelper.WriteLine("{0} {1} {2}", "[FModel]", "[WindowsApps]", "Folder not found");
+            return (string.Empty, string.Empty);
+        }
+        
         public static string GetFortnitePakFilesPath()
         {
             (_, string _, string fortniteFilesPath) = GetUEGameFilesPath("Fortnite");
@@ -76,22 +103,18 @@ namespace FModel.Utils
             return string.Empty;
         }
 
-        public static (string, string, string) GetUWPPakFilesPath(string game)
-        {
-            // WIP
-
-            DebugHelper.WriteLine("{0} {1} {2}", "[FModel]", "[]", "File not found");
-            return (string.Empty, string.Empty, string.Empty);
-        }
-
         public static string GetStateOfDecay2PakFilesPath()
         {
-            // WIP - DO NOT USE
-            (_, string _, string sod2PakFilesPath) = GetUWPPakFilesPath("Microsoft.Dayton_1.3544.68.2_x64__8wekyb3d8bbwe");
+            // WIP
+            (_, string _, string sod2PakFilesPath) = (null, null, null);
+            if (!GetUWPPakFilesPath("Microsoft.Dayton_1.3544.68.2_x64__8wekyb3d8bbwe").Equals(null))
+                (_, sod2PakFilesPath) = GetUWPPakFilesPath("Microsoft.Dayton_1.3544.68.2_x64__8wekyb3d8bbwe");
+            else
+                (_, _, sod2PakFilesPath) = GetUEGameFilesPath("<Unknown Epic Games Name>");
+
             if (!string.IsNullOrEmpty(sod2PakFilesPath))
                 return $"{sod2PakFilesPath}\\StateOfDecay2\\Content\\Paks";
-            else
-                return string.Empty;
+            return string.Empty;
         }
 
         public static string GetBorderlands3PakFilesPath()

--- a/FModel/Utils/Paks.cs
+++ b/FModel/Utils/Paks.cs
@@ -76,6 +76,24 @@ namespace FModel.Utils
             return string.Empty;
         }
 
+        public static (string, string, string) GetUWPPakFilesPath(string game)
+        {
+            // WIP
+
+            DebugHelper.WriteLine("{0} {1} {2}", "[FModel]", "[]", "File not found");
+            return (string.Empty, string.Empty, string.Empty);
+        }
+
+        public static string GetStateOfDecay2PakFilesPath()
+        {
+            // WIP - DO NOT USE
+            (_, string _, string sod2PakFilesPath) = GetUWPPakFilesPath("Microsoft.Dayton_1.3544.68.2_x64__8wekyb3d8bbwe");
+            if (!string.IsNullOrEmpty(sod2PakFilesPath))
+                return $"{sod2PakFilesPath}\\StateOfDecay2\\Content\\Paks";
+            else
+                return string.Empty;
+        }
+
         public static string GetBorderlands3PakFilesPath()
         {
             (_, string _, string borderlands3FilesPath) = GetUEGameFilesPath("Catnip");

--- a/FModel/Windows/Launcher/FLauncher.xaml.cs
+++ b/FModel/Windows/Launcher/FLauncher.xaml.cs
@@ -87,6 +87,15 @@ namespace FModel.Windows.Launcher
                 ComboBoxVm.gamesCbViewModel.Add(new ComboBoxViewModel { Id = i++, Content = "Spellbreak", Property = spellbreakerFilesPath });
             }
 
+            string sod2Path = Paks.GetStateOfDecay2PakFilesPath();
+            if (!string.IsNullOrEmpty(sod2Path))
+            {
+                // WIP - DO NOT USE
+                //DebugHelper.WriteLine("{0} {1} {2}", "[FModel]", "[LauncherInstalled.dat]", $"Spellbreak found at {spellbreakerFilesPath}");
+                //Globals.gNotifier.ShowCustomMessage("Spellbreak", Properties.Resources.PathAutoDetected, "/FModel;component/Resources/spellbreak.ico");
+                //ComboBoxVm.gamesCbViewModel.Add(new ComboBoxViewModel { Id = i++, Content = "Spellbreak", Property = spellbreakerFilesPath });
+            }
+
             Games_CbBox.SelectedItem = ComboBoxVm.gamesCbViewModel.Where(x => x.Property.ToString() == Properties.Settings.Default.PakPath).FirstOrDefault();
         }
 


### PR DESCRIPTION
For this Pull Request, it hopefully adds support for games installed from the Microsoft Store.

Currently it only supports games that are installed on the C drive.

I need help from anyone that has an Unreal Engine game that's installed from the Microsoft Store, preferably State of Decay 2, and has already made permissions changes to allow FModel to view the paks.

Also if anyone has State of Decay 2 on the Epic Games Launcher, please comment on this PR with your LauncherInstalled.dat file attached.

Thanks!