### PR TITLE
CRD_Melee WID Support

### DIFF
--- a/FModel/Creator/CreatorPackage.cs
+++ b/FModel/Creator/CreatorPackage.cs
@@ -32,6 +32,7 @@ namespace FModel.Creator
             switch (_object.ExportType)
             {
                 // Fortnite
+                case "FortCreativeWeaponMeleeItemDefinition":
                 case "AthenaConsumableEmoteItemDefinition":
                 case "AthenaSkyDiveContrailItemDefinition":
                 case "AthenaLoadingScreenItemDefinition":


### PR DESCRIPTION
The following WIDs listed below used a new type of "FortCreativeWeaponMeleeItemDefinition" so I decided to throw in a quick fix to allow those icons to be generated.

WID_Creative_Melee_Sword_Ninja
WID_Creative_Melee_Spear_Basic
WID_Creative_Melee_Hammer_SledgeWrapped