### PR TITLE
Headshot Damage in item viewer

### DIFF
--- a/FModel/Creator/Bases/FN/BaseIconStats.cs
+++ b/FModel/Creator/Bases/FN/BaseIconStats.cs
@@ -86,7 +86,12 @@ namespace FModel.Creator.Bases.FN
             {
                 if (weaponRowValue.TryGetValue(out float dmgPb, "DmgPB") && dmgPb != 0f && weaponRowValue.TryGetValue(out int bpc , "BulletsPerCartridge"))
                 {
-                    _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "BF7E3CF34A9ACFF52E95EAAD4F09F133", "Damage to Player"), dmgPb * (bpc != 0f ? bpc : 1), 200));
+                    _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "35D04D1B45737BEA25B69686D9E085B9", "Damage"), dmgPb * (bpc != 0f ? bpc : 1), 200));
+                }
+
+                if (weaponRowValue.TryGetValue(out int bpc2, "BulletsPerCartridge") && weaponRowValue.TryGetValue(out float DamageZone_Critical, "DamageZone_Critical"))
+                {
+                    _statistics.Add(new IconStat(Utils.GetLocalizedResource("", "0DEF2455463B008C4499FEA03D149EDF", "Headshot Damage"), dmgPb * DamageZone_Critical * (bpc2 != 0f ? bpc2 : 1), 200));
                 }
 
                 if (weaponRowValue.TryGetValue(out int clipSize, "ClipSize") && clipSize != 0)


### PR DESCRIPTION
Feel like headshot damage is an important enough stat to need to be on here, code isn't particularly perfect from what I know but I can't seem to make it work any other way, also changed "Damage to Player" to "Damage" because Save the World items also use this same viewer and your obviously not going to be hitting players in there.