### PR TITLE
Allow game forcing

### DIFF
--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -102,6 +102,22 @@ namespace FModel.Settings
             set => SetProperty(ref _overwriteMapping, value);
         }
 
+        private bool _forceGame;
+
+        public bool ForceGame
+        {
+            get => _forceGame;
+            set => SetProperty(ref _forceGame, value);
+        }
+
+        private FGame _gameToForce;
+
+        public FGame GameToForce
+        {
+            get => _gameToForce;
+            set => SetProperty(ref _gameToForce, value);
+        }
+
         private string _mappingFilePath;
         public string MappingFilePath
         {

--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -101,7 +101,16 @@ namespace FModel.ViewModels
                 }
                 default:
                 {
-                    Game = gameDirectory.SubstringBeforeLast("\\Content").SubstringAfterLast("\\").ToEnum(FGame.Unknown);
+                    if (UserSettings.Default.ForceGame == true)
+                    {
+                        Game = UserSettings.Default.GameToForce;
+                    }
+                    else
+                    {
+                        Game = gameDirectory.SubstringBeforeLast("\\Content").SubstringAfterLast("\\")
+                            .ToEnum(FGame.Unknown);
+                    }
+
                     var versions = new VersionContainer(UserSettings.Default.OverridedGame[Game], UserSettings.Default.OverridedPlatform,
                         customVersions: UserSettings.Default.OverridedCustomVersions[Game],
                         optionOverrides: UserSettings.Default.OverridedOptions[Game]);

--- a/FModel/ViewModels/SettingsViewModel.cs
+++ b/FModel/ViewModels/SettingsViewModel.cs
@@ -83,17 +83,11 @@ public class SettingsViewModel : ViewModel
     }
 
     private EDiscordRpc _selectedDiscordRpc;
+
     public EDiscordRpc SelectedDiscordRpc
     {
         get => _selectedDiscordRpc;
         set => SetProperty(ref _selectedDiscordRpc, value);
-    }
-
-    private ECompressedAudio _selectedCompressedAudio;
-    public ECompressedAudio SelectedCompressedAudio
-    {
-        get => _selectedCompressedAudio;
-        set => SetProperty(ref _selectedCompressedAudio, value);
     }
 
     private FGame _selectedForceGame;
@@ -227,6 +221,7 @@ public class SettingsViewModel : ViewModel
         SelectedTextureExportFormat = _textureExportFormatSnapshot;
         SelectedAesReload = UserSettings.Default.AesReload;
         SelectedDiscordRpc = UserSettings.Default.DiscordRpc;
+        SelectedForceGame = UserSettings.Default.GameToForce;
 
         UpdateModes = new ReadOnlyObservableCollection<EUpdateMode>(new ObservableCollection<EUpdateMode>(EnumerateUpdateModes()));
         Presets = new ObservableCollection<string>(EnumeratePresets());

--- a/FModel/ViewModels/SettingsViewModel.cs
+++ b/FModel/ViewModels/SettingsViewModel.cs
@@ -89,6 +89,13 @@ namespace FModel.ViewModels
             set => SetProperty(ref _selectedDiscordRpc, value);
         }
 
+        private FGame _selectedForceGame;
+        public FGame SelectedForceGame
+        {
+            get => _selectedForceGame;
+            set => SetProperty(ref _selectedForceGame, value);
+        }
+
         private ECompressedAudio _selectedCompressedAudio;
         public ECompressedAudio SelectedCompressedAudio
         {
@@ -127,6 +134,7 @@ namespace FModel.ViewModels
         public ReadOnlyObservableCollection<EUpdateMode> UpdateModes { get; private set; }
         public ObservableCollection<string> Presets { get; private set; }
         public ReadOnlyObservableCollection<EGame> UeGames { get; private set; }
+        public ReadOnlyObservableCollection<FGame> GameTypes { get; private set; }
         public ReadOnlyObservableCollection<ELanguage> AssetLanguages { get; private set; }
         public ReadOnlyObservableCollection<EAesReload> AesReloads { get; private set; }
         public ReadOnlyObservableCollection<EDiscordRpc> DiscordRpcs { get; private set; }
@@ -211,10 +219,12 @@ namespace FModel.ViewModels
             SelectedTextureExportFormat = _textureExportFormatSnapshot;
             SelectedAesReload = UserSettings.Default.AesReload;
             SelectedDiscordRpc = UserSettings.Default.DiscordRpc;
+            SelectedForceGame = UserSettings.Default.GameToForce;
 
             UpdateModes = new ReadOnlyObservableCollection<EUpdateMode>(new ObservableCollection<EUpdateMode>(EnumerateUpdateModes()));
             Presets = new ObservableCollection<string>(EnumeratePresets());
             UeGames = new ReadOnlyObservableCollection<EGame>(new ObservableCollection<EGame>(EnumerateUeGames()));
+            GameTypes = new ReadOnlyObservableCollection<FGame>(new ObservableCollection<FGame>(EnumerateGameTypes()));
             AssetLanguages = new ReadOnlyObservableCollection<ELanguage>(new ObservableCollection<ELanguage>(EnumerateAssetLanguages()));
             AesReloads = new ReadOnlyObservableCollection<EAesReload>(new ObservableCollection<EAesReload>(EnumerateAesReloads()));
             DiscordRpcs = new ReadOnlyObservableCollection<EDiscordRpc>(new ObservableCollection<EDiscordRpc>(EnumerateDiscordRpcs()));
@@ -323,6 +333,7 @@ namespace FModel.ViewModels
             yield return Constants._NO_PRESET_TRIGGER;
         }
         private IEnumerable<EGame> EnumerateUeGames() => Enum.GetValues<EGame>();
+        private IEnumerable<FGame> EnumerateGameTypes() => Enum.GetValues<FGame>();
         private IEnumerable<ELanguage> EnumerateAssetLanguages() => Enum.GetValues<ELanguage>();
         private IEnumerable<EAesReload> EnumerateAesReloads() => Enum.GetValues<EAesReload>();
         private IEnumerable<EDiscordRpc> EnumerateDiscordRpcs() => Enum.GetValues<EDiscordRpc>();

--- a/FModel/Views/SettingsView.xaml
+++ b/FModel/Views/SettingsView.xaml
@@ -41,6 +41,8 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -244,6 +246,44 @@
                              Visibility="{Binding OverwriteMapping, Source={x:Static local:Settings.UserSettings.Default}, Converter={StaticResource BoolToVisibilityConverter}}"/>
                     <Button Grid.Row="15" Grid.Column="6" Content="..." HorizontalAlignment="Right" Click="OnBrowseMappings" Margin="0 0 0 5"
                             Visibility="{Binding OverwriteMapping, Source={x:Static local:Settings.UserSettings.Default}, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+
+                    <TextBlock Grid.Row="16" Grid.Column="0" Text="Force Game Type" VerticalAlignment="Center" Margin="0 0 0 5"
+                               DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Views.SettingsView}}}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <CheckBox Grid.Row="16" Grid.Column="2" Content="{Binding IsChecked, RelativeSource={RelativeSource Self}, Converter={x:Static converters:BoolToToggleConverter.Instance}}"
+                              IsChecked="{Binding ForceGame, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}" Margin="0 5 0 10"
+                              DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Views.SettingsView}}}">
+                        <CheckBox.Style>
+                            <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </Style>
+                        </CheckBox.Style>
+                    </CheckBox>
+
+                    <TextBlock Grid.Row="17" Grid.Column="0" Text="Game Type" VerticalAlignment="Center" Margin="0 0 0 5"
+                               Visibility="{Binding ForceGame, Source={x:Static local:Settings.UserSettings.Default}, Converter={StaticResource BoolToVisibilityConverter}}" />
+
+                    <ComboBox Grid.Row="17" Grid.Column="2" Grid.ColumnSpan="5" ItemsSource="{Binding SettingsView.GameTypes}" SelectedItem="{Binding SettingsView.SelectedForceGame, Mode=TwoWay}"
+                              DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Views.SettingsView}}}"
+                              SelectedValue="{Binding GameToForce, Source={x:Static local:Settings.UserSettings.Default}, Mode=TwoWay}" Margin="0 5 0 10">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Converter={x:Static converters:EnumToStringConverter.Instance}}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                        <ComboBox.Style>
+                            <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+                                <Setter Property="Visibility" Value="{Binding ForceGame, Source={x:Static local:Settings.UserSettings.Default}, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            </Style>
+                        </ComboBox.Style>
+                    </ComboBox>
                 </Grid>
             </DataTemplate>
             <DataTemplate x:Key="CreatorTemplate">


### PR DESCRIPTION
Allow users to over-write the auto-detected game set by FModel. This will allow any user to operate FModel in any folder under a certain game type. This also addresses issues I brought up in #288.