### PR TITLE
Fixes the error when opening playlists without images

### DIFF
--- a/FModel/Creator/Bases/FN/BasePlaylist.cs
+++ b/FModel/Creator/Bases/FN/BasePlaylist.cs
@@ -34,7 +34,7 @@ public class BasePlaylist : UCreator
             return;
 
         var playlist = _apiEndpointView.FortniteApi.GetPlaylist(playlistName.Text);
-        if (!playlist.IsSuccess || !playlist.Data.Images.HasShowcase ||
+        if (!playlist.IsSuccess || playlist.Data.Images == null || !playlist.Data.Images.HasShowcase ||
             !_apiEndpointView.FortniteApi.TryGetBytes(playlist.Data.Images.Showcase, out var image))
             return;
 


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/162e5a47-c3cd-4e39-b151-6fd0d3a2a104)

after:

![image](https://github.com/user-attachments/assets/42d615c1-49b5-48d1-b537-75a5d46f4e2c)
