### PR TITLE
Add save audio option to context menus

### DIFF
--- a/FModel/Enums.cs
+++ b/FModel/Enums.cs
@@ -114,5 +114,6 @@ public enum EBulkType
     Textures =      1 << 2,
     Meshes =        1 << 3,
     Skeletons =     1 << 4,
-    Animations =    1 << 5
+    Animations =    1 << 5,
+    Audio =         1 << 6
 }

--- a/FModel/MainWindow.xaml
+++ b/FModel/MainWindow.xaml
@@ -376,6 +376,15 @@
                                                 </Viewbox>
                                             </MenuItem.Icon>
                                         </MenuItem>
+                                        <MenuItem Header="Save Folder's Packages Audio" Click="OnFolderAudioClick">
+                                            <MenuItem.Icon>
+                                                <Viewbox Width="16" Height="16">
+                                                    <Canvas Width="24" Height="24">
+                                                        <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource AudioIcon}" />
+                                                    </Canvas>
+                                                </Viewbox>
+                                            </MenuItem.Icon>
+                                        </MenuItem>
                                         <Separator />
                                         <MenuItem Header="Favorite Directory" Click="OnFavoriteDirectoryClick">
                                             <MenuItem.Icon>
@@ -604,6 +613,21 @@
                                                     <Viewbox Width="16" Height="16">
                                                         <Canvas Width="24" Height="24">
                                                             <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource AnimationIcon}" />
+                                                        </Canvas>
+                                                    </Viewbox>
+                                                </MenuItem.Icon>
+                                            </MenuItem>
+                                            <MenuItem Header="Save Audio" Command="{Binding DataContext.RightClickMenuCommand}">
+                                                <MenuItem.CommandParameter>
+                                                    <MultiBinding Converter="{x:Static converters:MultiParameterConverter.Instance}">
+                                                        <Binding Source="Assets_Save_Audio" />
+                                                        <Binding Path="SelectedItems" />
+                                                    </MultiBinding>
+                                                </MenuItem.CommandParameter>
+                                                <MenuItem.Icon>
+                                                    <Viewbox Width="16" Height="16">
+                                                        <Canvas Width="24" Height="24">
+                                                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource AudioIcon}" />
                                                         </Canvas>
                                                     </Viewbox>
                                                 </MenuItem.Icon>

--- a/FModel/MainWindow.xaml
+++ b/FModel/MainWindow.xaml
@@ -103,9 +103,6 @@
                         </Viewbox>
                     </MenuItem.Icon>
                 </MenuItem>
-                <Separator />
-                <MenuItem Header="Auto Open Sounds" IsCheckable="True" StaysOpenOnClick="True"
-                          IsChecked="{Binding IsAutoOpenSounds, Source={x:Static settings:UserSettings.Default}}" />
             </MenuItem>
             <MenuItem Header="Views">
                 <MenuItem Header="3D Viewer" Command="{Binding MenuCommand}" CommandParameter="Views_3dViewer">
@@ -860,19 +857,6 @@
                                 <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.AccentForegroundBrush}}" Data="{StaticResource StatusBarIcon}" />
                             </Canvas>
                         </Viewbox>
-                    </StatusBarItem>
-
-                    <StatusBarItem Width="30" HorizontalContentAlignment="Stretch" ToolTip="Auto Open Sounds Enabled">
-                        <StatusBarItem.Style>
-                            <Style TargetType="StatusBarItem">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsAutoOpenSounds, Source={x:Static settings:UserSettings.Default}}" Value="False">
-                                        <Setter Property="Visibility" Value="Collapsed" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </StatusBarItem.Style>
-                        <TextBlock HorizontalAlignment="Center" FontWeight="SemiBold" Text="SND" />
                     </StatusBarItem>
 
                     <StatusBarItem Margin="10 0 0 0">

--- a/FModel/MainWindow.xaml.cs
+++ b/FModel/MainWindow.xaml.cs
@@ -246,7 +246,7 @@ public partial class MainWindow
             FLogger.Append(ELog.Information, () =>
             {
                 FLogger.Text("Successfully saved audio from ", Constants.WHITE);
-                FLogger.Link(folder.PathAtThisPoint, UserSettings.Default.ModelDirectory, true);
+                FLogger.Link(folder.PathAtThisPoint, UserSettings.Default.AudioDirectory, true);
             });
         }
     }

--- a/FModel/MainWindow.xaml.cs
+++ b/FModel/MainWindow.xaml.cs
@@ -238,6 +238,19 @@ public partial class MainWindow
         }
     }
 
+    private async void OnFolderAudioClick(object sender, RoutedEventArgs e)
+    {
+        if (AssetsFolderName.SelectedItem is TreeItem folder)
+        {
+            await _threadWorkerView.Begin(cancellationToken => { _applicationView.CUE4Parse.AudioFolder(cancellationToken, folder); });
+            FLogger.Append(ELog.Information, () =>
+            {
+                FLogger.Text("Successfully saved audio from ", Constants.WHITE);
+                FLogger.Link(folder.PathAtThisPoint, UserSettings.Default.ModelDirectory, true);
+            });
+        }
+    }
+
     private void OnFavoriteDirectoryClick(object sender, RoutedEventArgs e)
     {
         if (AssetsFolderName.SelectedItem is not TreeItem folder) return;

--- a/FModel/Settings/UserSettings.cs
+++ b/FModel/Settings/UserSettings.cs
@@ -140,13 +140,6 @@ namespace FModel.Settings
             set => SetProperty(ref _lastOpenedSettingTab, value);
         }
 
-        private bool _isAutoOpenSounds = true;
-        public bool IsAutoOpenSounds
-        {
-            get => _isAutoOpenSounds;
-            set => SetProperty(ref _isAutoOpenSounds, value);
-        }
-
         private bool _isLoggerExpanded = true;
         public bool IsLoggerExpanded
         {

--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -1111,7 +1111,7 @@ public class CUE4ParseViewModel : ViewModel
         var savedAudioPath = Path.Combine(UserSettings.Default.AudioDirectory,
             UserSettings.Default.KeepDirectoryStructure ? fullPath : fullPath.SubstringAfterLast('/')).Replace('\\', '/') + $".{ext.ToLowerInvariant()}";
 
-        if (!UserSettings.Default.IsAutoOpenSounds || isBulk)
+        if (isBulk)
         {
             Directory.CreateDirectory(savedAudioPath.SubstringBeforeLast('/'));
             using var stream = new FileStream(savedAudioPath, FileMode.Create, FileAccess.Write);

--- a/FModel/ViewModels/Commands/RightClickMenuCommand.cs
+++ b/FModel/ViewModels/Commands/RightClickMenuCommand.cs
@@ -92,6 +92,14 @@ public class RightClickMenuCommand : ViewModelCommand<ApplicationViewModel>
                         contextViewModel.CUE4Parse.Extract(cancellationToken, entry, false, EBulkType.Animations | updateUi);
                     }
                     break;
+                case "Assets_Save_Audio":
+                    foreach (var entry in entries)
+                    {
+                        Thread.Yield();
+                        cancellationToken.ThrowIfCancellationRequested();
+                        contextViewModel.CUE4Parse.Extract(cancellationToken, entry, false, EBulkType.Audio | updateUi);
+                    }
+                    break;
             }
         });
     }

--- a/FModel/ViewModels/Commands/TabCommand.cs
+++ b/FModel/ViewModels/Commands/TabCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using AdonisUI.Controls;
 using FModel.Framework;
 using FModel.Services;
@@ -56,6 +56,12 @@ public class TabCommand : ViewModelCommand<TabItem>
                 await _threadWorkerView.Begin(cancellationToken =>
                 {
                     _applicationView.CUE4Parse.Extract(cancellationToken, tabViewModel.Entry, false, EBulkType.Animations);
+                });
+                break;
+            case "Asset_Save_Audio":
+                await _threadWorkerView.Begin(cancellationToken =>
+                {
+                    _applicationView.CUE4Parse.Extract(cancellationToken, tabViewModel.Entry, false, EBulkType.Audio);
                 });
                 break;
             case "Open_Properties":

--- a/FModel/Views/Resources/Resources.xaml
+++ b/FModel/Views/Resources/Resources.xaml
@@ -909,6 +909,15 @@
                                         </Viewbox>
                                     </MenuItem.Icon>
                                 </MenuItem>
+                                <MenuItem Header="Save Audio" Command="{Binding TabCommand}" CommandParameter="Asset_Save_Audio">
+                                    <MenuItem.Icon>
+                                        <Viewbox Width="16" Height="16">
+                                            <Canvas Width="24" Height="24">
+                                                <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource AudioIcon}" />
+                                            </Canvas>
+                                        </Viewbox>
+                                    </MenuItem.Icon>
+                                </MenuItem>
                                 <Separator />
                                 <MenuItem Header="Open Properties" Command="{Binding TabCommand}" CommandParameter="Open_Properties">
                                     <MenuItem.Icon>

--- a/FModel/Views/SearchView.xaml
+++ b/FModel/Views/SearchView.xaml
@@ -1,4 +1,4 @@
-﻿<adonisControls:AdonisWindow x:Class="FModel.Views.SearchView"
+<adonisControls:AdonisWindow x:Class="FModel.Views.SearchView"
                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                              xmlns:converters="clr-namespace:FModel.Views.Resources.Converters"
@@ -250,6 +250,21 @@
                                     <Viewbox Width="16" Height="16">
                                         <Canvas Width="24" Height="24">
                                             <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource AnimationIcon}" />
+                                        </Canvas>
+                                    </Viewbox>
+                                </MenuItem.Icon>
+                            </MenuItem>
+                            <MenuItem Header="Save Audio" Command="{Binding DataContext.RightClickMenuCommand}">
+                                <MenuItem.CommandParameter>
+                                    <MultiBinding Converter="{x:Static converters:MultiParameterConverter.Instance}">
+                                        <Binding Source="Assets_Save_Audio" />
+                                        <Binding Path="SelectedItems" />
+                                    </MultiBinding>
+                                </MenuItem.CommandParameter>
+                                <MenuItem.Icon>
+                                    <Viewbox Width="16" Height="16">
+                                        <Canvas Width="24" Height="24">
+                                            <Path Fill="{DynamicResource {x:Static adonisUi:Brushes.ForegroundBrush}}" Data="{StaticResource AudioIcon}" />
                                         </Canvas>
                                     </Viewbox>
                                 </MenuItem.Icon>


### PR DESCRIPTION
I like video game music and want to extract them in bulk instead of having to open each separate file. This patch allows extracting them in bulk like with textures and models. Note it doesn't automatically convert the audio like it would if you opened the audio in the audio player.