### PR TITLE
FModel running within zip prevention

### DIFF
--- a/FModel/App.xaml.cs
+++ b/FModel/App.xaml.cs
@@ -15,6 +15,7 @@ using Newtonsoft.Json;
 using Serilog.Sinks.SystemConsole.Themes;
 using MessageBox = AdonisUI.Controls.MessageBox;
 using MessageBoxImage = AdonisUI.Controls.MessageBoxImage;
+using MessageBoxButton = AdonisUI.Controls.MessageBoxButton;
 using MessageBoxResult = AdonisUI.Controls.MessageBoxResult;
 
 namespace FModel;
@@ -33,6 +34,27 @@ public partial class App
 
     protected override void OnStartup(StartupEventArgs e)
     {
+        var exeDir = AppContext.BaseDirectory;
+        if (exeDir.Contains(".zip"))
+        {
+            var owner = Current?.MainWindow;
+
+            if (owner != null)
+            {
+                owner.Topmost = true;
+                owner.Activate();
+            }
+
+            MessageBox.Show(
+                owner,
+                "Please extract FModel from the ZIP before running.",
+                "Fatal Error",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error
+            );
+
+            Environment.Exit(1);
+        }
 #if DEBUG
         AttachConsole(-1);
 #endif

--- a/FModel/MainWindow.xaml.cs
+++ b/FModel/MainWindow.xaml.cs
@@ -12,6 +12,8 @@ using FModel.ViewModels;
 using FModel.Views;
 using FModel.Views.Resources.Controls;
 using ICSharpCode.AvalonEdit.Editing;
+using MessageBox = AdonisUI.Controls.MessageBox;
+using MessageBoxImage = AdonisUI.Controls.MessageBoxImage;
 
 namespace FModel;
 
@@ -84,6 +86,28 @@ public partial class MainWindow
 
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
+        var exeDir = AppContext.BaseDirectory;
+        if (exeDir.Contains(".zip"))
+        {
+            var owner = Application.Current?.MainWindow;
+
+            if (owner != null)
+            {
+                owner.Topmost = true;
+                owner.Activate();
+            }
+
+            MessageBox.Show(
+                owner,
+                "Please extract FModel from the ZIP before running.",
+                "Fatal Error",
+                AdonisUI.Controls.MessageBoxButton.OK,
+                MessageBoxImage.Error
+            );
+
+            Environment.Exit(1);
+        }
+
         var newOrUpdated = UserSettings.Default.ShowChangelog;
 #if !DEBUG
         ApplicationService.ApiEndpointView.FModelApi.CheckForUpdates(true);

--- a/FModel/MainWindow.xaml.cs
+++ b/FModel/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using FModel.Views;
 using FModel.Views.Resources.Controls;
 using ICSharpCode.AvalonEdit.Editing;
 using MessageBox = AdonisUI.Controls.MessageBox;
+using MessageBoxButton = AdonisUI.Controls.MessageBoxButton;
 using MessageBoxImage = AdonisUI.Controls.MessageBoxImage;
 
 namespace FModel;
@@ -101,7 +102,7 @@ public partial class MainWindow
                 owner,
                 "Please extract FModel from the ZIP before running.",
                 "Fatal Error",
-                AdonisUI.Controls.MessageBoxButton.OK,
+                MessageBoxButton.OK,
                 MessageBoxImage.Error
             );
 

--- a/FModel/MainWindow.xaml.cs
+++ b/FModel/MainWindow.xaml.cs
@@ -12,9 +12,6 @@ using FModel.ViewModels;
 using FModel.Views;
 using FModel.Views.Resources.Controls;
 using ICSharpCode.AvalonEdit.Editing;
-using MessageBox = AdonisUI.Controls.MessageBox;
-using MessageBoxButton = AdonisUI.Controls.MessageBoxButton;
-using MessageBoxImage = AdonisUI.Controls.MessageBoxImage;
 
 namespace FModel;
 
@@ -87,28 +84,6 @@ public partial class MainWindow
 
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
-        var exeDir = AppContext.BaseDirectory;
-        if (exeDir.Contains(".zip"))
-        {
-            var owner = Application.Current?.MainWindow;
-
-            if (owner != null)
-            {
-                owner.Topmost = true;
-                owner.Activate();
-            }
-
-            MessageBox.Show(
-                owner,
-                "Please extract FModel from the ZIP before running.",
-                "Fatal Error",
-                MessageBoxButton.OK,
-                MessageBoxImage.Error
-            );
-
-            Environment.Exit(1);
-        }
-
         var newOrUpdated = UserSettings.Default.ShowChangelog;
 #if !DEBUG
         ApplicationService.ApiEndpointView.FModelApi.CheckForUpdates(true);


### PR DESCRIPTION
Running FModel within a zip causes issues that does not explain the issue
<img width="451" height="148" alt="image" src="https://github.com/user-attachments/assets/4941adf1-3499-4115-a736-a854f607c4c8" />

so it now checks if FModel is within a zip

<img width="429" height="199" alt="image" src="https://github.com/user-attachments/assets/14b1d312-1ab4-43f4-a18d-3c5debd9fba9" />