### PR TITLE
temporary fix manifest errors

### DIFF
--- a/FModel/ViewModels/CUE4ParseViewModel.cs
+++ b/FModel/ViewModels/CUE4ParseViewModel.cs
@@ -260,7 +260,7 @@ public class CUE4ParseViewModel : ViewModel
                             {
                                 (manifest, _) = manifestInfo.DownloadAndParseAsync(manifestOptions,
                                     cancellationToken: cancellationToken,
-                                    elementManifestPredicate: static x => x.Uri.Host == "download.epicgames.com"
+                                    elementManifestPredicate: static x => x.Uri.Host == "download.epicgames.com" || x.Uri.Host == "epicgames-download1.akamaized.net"
                                 ).GetAwaiter().GetResult();
                             }
                             catch (HttpRequestException ex)


### PR DESCRIPTION
Fixed "`Could not find ManifestInfoElement based on predicate`" by adding `epicgames-download1.akamaized.net` in the manifest predicate as `download.epicgames.com` seems to not be present in the manifest response.